### PR TITLE
This commit refactors the settings screen by moving the UI to the mai…

### DIFF
--- a/app/src/main/java/com/kerberos/trackingSdk/MainActivity.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.kerberos.livetrackingsdk.ui.settings.SettingsScreen
+import com.kerberos.trackingSdk.ui.settings.SettingsScreen
 import com.kerberos.trackingSdk.ui.BottomNavigationBar
 import com.kerberos.trackingSdk.ui.theme.ui.theme.MyApplicationTheme
 import com.kerberos.trackingSdk.ui.trip.TripMapScreen

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/settings/SettingsScreen.kt
@@ -1,4 +1,4 @@
-package com.kerberos.livetrackingsdk.ui.settings
+package com.kerberos.trackingSdk.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.kerberos.livetrackingsdk.ui.settings.SettingsViewModel
 import org.koin.androidx.compose.koinViewModel
 
 @Composable

--- a/liveTrackingSdk/src/main/AndroidManifest.xml
+++ b/liveTrackingSdk/src/main/AndroidManifest.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
 </manifest>


### PR DESCRIPTION
…n application and keeping the logic in the liveTrackingSdk module.

This change improves the separation of concerns by having the UI of the settings screen in the `app` module, while the business logic and data persistence remain in the `liveTrackingSdk` module.