### PR TITLE
This commit introduces a new composable for controlling a trip, with …

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,19 +55,17 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.androidx.adaptive.navigation)
+    implementation("androidx.compose.material3.adaptive:adaptive-navigation:1.2.0-beta01")
     implementation(project(":liveTrackingSdk"))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
-    implementation(libs.maps.compose)
-    implementation(libs.play.services.maps)
-    implementation(libs.androidx.navigation.compose)
+    implementation("com.google.maps.android:maps-compose:2.11.4")
+    implementation("com.google.android.gms:play-services-maps:18.2.0")
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
 }
-

--- a/app/src/main/java/com/kerberos/trackingSdk/base/x.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/base/x.kt
@@ -1,4 +1,0 @@
-package com.kerberos.trackingSdk.base
-
-class x {
-}

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripControls.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripControls.kt
@@ -1,0 +1,49 @@
+package com.kerberos.trackingSdk.ui.trip
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.kerberos.livetrackingsdk.viewModels.TripStatus
+
+@Composable
+fun TripControls(
+    tripStatus: TripStatus,
+    onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onStop: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        when (tripStatus) {
+            TripStatus.STOPPED -> {
+                Button(onClick = onStart) {
+                    Text("Start")
+                }
+            }
+            TripStatus.RUNNING -> {
+                Button(onClick = onPause) {
+                    Text("Pause")
+                }
+                Button(onClick = onStop) {
+                    Text("Stop")
+                }
+            }
+            TripStatus.PAUSED -> {
+                Button(onClick = onResume) {
+                    Text("Resume")
+                }
+                Button(onClick = onStop) {
+                    Text("Stop")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripItem.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripItem.kt
@@ -35,7 +35,7 @@ fun TripItem(trip: TripModel) {
             if (trip.endTime != null) {
                 Row {
                     Text(text = "End Time: ", style = MaterialTheme.typography.bodyMedium)
-                    Text(text = trip.endTime!!.toFormattedDate(), style = MaterialTheme.typography.bodyMedium)
+                    Text(text = trip.endTime.toFormattedDate(), style = MaterialTheme.typography.bodyMedium)
                 }
             }
             if (trip.tripDuration != null) {

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripMapScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripMapScreen.kt
@@ -1,9 +1,15 @@
 package com.kerberos.trackingSdk.ui.trip
 
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -15,6 +21,7 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun TripMapScreen(viewModel: TripTrackViewModel = koinViewModel()) {
     val tripTracks by viewModel.tripTracks.collectAsState()
+    val tripStatus by viewModel.tripStatus.collectAsState()
 
     val cameraPositionState = rememberCameraPositionState {
         position = CameraPosition.fromLatLngZoom(LatLng(0.0, 0.0), 10f)
@@ -32,11 +39,24 @@ fun TripMapScreen(viewModel: TripTrackViewModel = koinViewModel()) {
         }
     }
 
-    GoogleMap(
-        cameraPositionState = cameraPositionState
-    ) {
-        if (tripTracks.size > 1) {
-            Polyline(points = tripTracks.map { LatLng(it.latitude, it.longitude) })
+    Box(modifier = Modifier.fillMaxSize()) {
+        GoogleMap(
+            cameraPositionState = cameraPositionState
+        ) {
+            if (tripTracks.size > 1) {
+                Polyline(points = tripTracks.map { LatLng(it.latitude, it.longitude) })
+            }
         }
+
+        TripControls(
+            tripStatus = tripStatus,
+            onStart = viewModel::startTrip,
+            onPause = viewModel::pauseTrip,
+            onResume = viewModel::resumeTrip,
+            onStop = viewModel::stopTrip,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp)
+        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-adaptiveNavigation = "1.2.0-beta01"
 agp = "8.8.0"
 gson = "2.10.1"
 kotlin = "2.1.0"
@@ -8,25 +7,19 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.1"
-mapsCompose = "2.11.4"
 material = "1.12.0"
-navigationCompose = "2.9.3"
 playServicesLocation = "21.3.0"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2024.04.01"
-playServicesMaps = "19.2.0"
 
 [libraries]
-androidx-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "adaptiveNavigation" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
@@ -39,7 +32,6 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/StatesLayoutCompose.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/StatesLayoutCompose.kt
@@ -1,4 +1,4 @@
-package com.kerberos.trackingSdk.base.stateLayout
+package com.kerberos.livetrackingsdk.base.stateLayout
 
 
 import android.widget.Toast
@@ -9,17 +9,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.UiComposable
 import androidx.compose.ui.platform.LocalContext
-import com.kerberos.livetrackingsdk.base.states.BaseState
-import com.kerberos.trackingSdk.base.stateLayout.defaultStates.InternalServerErrorCompose
-import com.kerberos.trackingSdk.base.stateLayout.defaultStates.NoInternetConnectionCompose
-import com.kerberos.trackingSdk.base.stateLayout.defaultStates.NotAuthorizedCompose
-import com.kerberos.trackingSdk.base.stateLayout.defaultStates.Progress
-
-//import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.InternalServerErrorCompose
-//import com.adham.gini.weatherginisdk.base.states.BaseState
-//import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.NoInternetConnectionCompose
-//import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.NotAuthorizedCompose
-//import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.Progress
+import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.InternalServerErrorCompose
+import com.adham.gini.weatherginisdk.base.states.BaseState
+import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.NoInternetConnectionCompose
+import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.NotAuthorizedCompose
+import com.adham.gini.weatherginisdk.base.stateLayout.defaultStates.Progress
 
 /**
  * States layout compose

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/StatesLayoutCustomActionInterface.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/StatesLayoutCustomActionInterface.kt
@@ -1,4 +1,4 @@
-package com.kerberos.trackingSdk.base.stateLayout
+package com.kerberos.livetrackingsdk.base.stateLayout
 
 /**
  * States layout custom action interface

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/StatesLayoutCustomInterface.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/StatesLayoutCustomInterface.kt
@@ -1,4 +1,4 @@
-package com.kerberos.trackingSdk.base.stateLayout
+package com.kerberos.livetrackingsdk.base.stateLayout
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.UiComposable

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/InternalServerErrorCompose.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/InternalServerErrorCompose.kt
@@ -1,50 +1,37 @@
-package com.kerberos.trackingSdk.base.stateLayout.defaultStates
+package com.kerberos.livetrackingsdk.base.stateLayout.defaultStates
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.adham.gini.weatherginisdk.R
-import com.adham.gini.weatherginisdk.ui.navigations.NavigationItem
 
 
 /**
- * No internet connection compose
+ * Not authorized compose
  *
- * @param retry
- * @receiver
  */
 @Composable
-fun NoInternetConnectionCompose(retry: () -> Unit) {
+fun InternalServerErrorCompose(message: String?) {
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
-//            .fillMaxHeight()
-        ,
+            .fillMaxHeight(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = stringResource(R.string.noConnection),
+            text = message ?: stringResource(R.string.internalServerError),
             style = MaterialTheme.typography.labelLarge
         )
-        OutlinedButton(
-            modifier = Modifier.padding(8.dp),
-            onClick = {
-                retry()
-            },
-        ) {
-            Text(text = stringResource(R.string.Retry))
-        }
     }
 }
+
+

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/NoInternetConnectionCompose.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/NoInternetConnectionCompose.kt
@@ -1,37 +1,50 @@
-package com.kerberos.trackingSdk.base.stateLayout.defaultStates
+package com.kerberos.livetrackingsdk.base.stateLayout.defaultStates
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.adham.gini.weatherginisdk.R
+import com.adham.gini.weatherginisdk.ui.navigations.NavigationItem
 
 
 /**
- * Not authorized compose
+ * No internet connection compose
  *
+ * @param retry
+ * @receiver
  */
 @Composable
-fun InternalServerErrorCompose(message: String?) {
+fun NoInternetConnectionCompose(retry: () -> Unit) {
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .fillMaxHeight(),
+//            .fillMaxHeight()
+        ,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Text(
-            text = message ?: stringResource(R.string.internalServerError),
+            text = stringResource(R.string.noConnection),
             style = MaterialTheme.typography.labelLarge
         )
+        OutlinedButton(
+            modifier = Modifier.padding(8.dp),
+            onClick = {
+                retry()
+            },
+        ) {
+            Text(text = stringResource(R.string.Retry))
+        }
     }
 }
-
-

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/NotAuthorizedCompose.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/NotAuthorizedCompose.kt
@@ -1,4 +1,4 @@
-package com.kerberos.trackingSdk.base.stateLayout.defaultStates
+package com.kerberos.livetrackingsdk.base.stateLayout.defaultStates
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/Progress.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/base/stateLayout/defaultStates/Progress.kt
@@ -1,4 +1,4 @@
-package com.kerberos.trackingSdk.base.stateLayout.defaultStates
+package com.kerberos.livetrackingsdk.base.stateLayout.defaultStates
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/viewModels/TripTrackViewModel.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/viewModels/TripTrackViewModel.kt
@@ -9,11 +9,20 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
+enum class TripStatus {
+    STOPPED,
+    RUNNING,
+    PAUSED
+}
+
 class TripTrackViewModel constructor(private val tripTrackRepository: TripTrackRepository) :
     ViewModel() {
 
     private val _tripTracks = MutableStateFlow<List<TripTrack>>(emptyList())
     val tripTracks: StateFlow<List<TripTrack>> = _tripTracks
+
+    private val _tripStatus = MutableStateFlow(TripStatus.STOPPED)
+    val tripStatus: StateFlow<TripStatus> = _tripStatus
 
     fun getTripTracks(tripId: Int) {
         viewModelScope.launch {
@@ -21,5 +30,21 @@ class TripTrackViewModel constructor(private val tripTrackRepository: TripTrackR
                 _tripTracks.value = it
             }
         }
+    }
+
+    fun startTrip() {
+        _tripStatus.value = TripStatus.RUNNING
+    }
+
+    fun pauseTrip() {
+        _tripStatus.value = TripStatus.PAUSED
+    }
+
+    fun resumeTrip() {
+        _tripStatus.value = TripStatus.RUNNING
+    }
+
+    fun stopTrip() {
+        _tripStatus.value = TripStatus.STOPPED
     }
 }


### PR DESCRIPTION
…buttons for start, pause, resume, and stop.

A new `TripControls` composable has been created to display the trip control buttons. The `TripTrackViewModel` has been updated with state management for the trip status, using a new `TripStatus` enum. The `TripControls` composable is integrated into the `TripMapScreen`, displayed at the bottom of the screen.