### PR TITLE
feat: Implement update and delete trip functionality

### DIFF
--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/factories/TripUseCaseFactory.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/factories/TripUseCaseFactory.kt
@@ -1,11 +1,14 @@
 package com.kerberos.livetrackingsdk.factories
 
 import com.google.gson.Gson
+import com.google.gson.Gson
 import com.kerberos.livetrackingsdk.importer.CsvTripImporterExporter
 import com.kerberos.livetrackingsdk.importer.JsonTripImporterExporter
 import com.kerberos.livetrackingsdk.repositories.repositories.TripRepository
+import com.kerberos.livetrackingsdk.useCases.DeleteTripUseCase
 import com.kerberos.livetrackingsdk.useCases.ExportTripsUseCase
 import com.kerberos.livetrackingsdk.useCases.ImportTripsUseCase
+import com.kerberos.livetrackingsdk.useCases.UpdateTripUseCase
 
 class TripUseCaseFactory(private val tripRepository: TripRepository, private val gson: Gson) {
 
@@ -25,5 +28,13 @@ class TripUseCaseFactory(private val tripRepository: TripRepository, private val
             else -> throw IllegalArgumentException("Unknown type: $type")
         }
         return ExportTripsUseCase(tripRepository, exporter)
+    }
+
+    fun createUpdateUseCase(): UpdateTripUseCase {
+        return UpdateTripUseCase(tripRepository)
+    }
+
+    fun createDeleteUseCase(): DeleteTripUseCase {
+        return DeleteTripUseCase(tripRepository)
     }
 }

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/repositories/repositories/TripRepository.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/repositories/repositories/TripRepository.kt
@@ -18,4 +18,12 @@ class TripRepository constructor(
         tripDao.insert(trips)
     }
 
+    suspend fun updateTrip(trip: Trip) {
+        tripDao.update(trip)
+    }
+
+    suspend fun deleteTrip(trip: Trip) {
+        tripDao.delete(trip)
+    }
+
 }

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/useCases/DeleteTripUseCase.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/useCases/DeleteTripUseCase.kt
@@ -1,0 +1,12 @@
+package com.kerberos.livetrackingsdk.useCases
+
+import com.kerberos.livetrackingsdk.orm.Trip
+import com.kerberos.livetrackingsdk.repositories.repositories.TripRepository
+
+class DeleteTripUseCase(
+    private val tripRepository: TripRepository
+) {
+    suspend fun execute(trip: Trip) {
+        tripRepository.deleteTrip(trip)
+    }
+}

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/useCases/UpdateTripUseCase.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/useCases/UpdateTripUseCase.kt
@@ -1,0 +1,12 @@
+package com.kerberos.livetrackingsdk.useCases
+
+import com.kerberos.livetrackingsdk.orm.Trip
+import com.kerberos.livetrackingsdk.repositories.repositories.TripRepository
+
+class UpdateTripUseCase(
+    private val tripRepository: TripRepository
+) {
+    suspend fun execute(trip: Trip) {
+        tripRepository.updateTrip(trip)
+    }
+}

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/viewModels/TripViewModel.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/viewModels/TripViewModel.kt
@@ -8,6 +8,7 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.aljawad.sons.gorestrepository.repositories.TripPagingRepository
 import com.kerberos.livetrackingsdk.factories.TripUseCaseFactory
+import com.kerberos.livetrackingsdk.mappers.toTrip
 import com.kerberos.livetrackingsdk.models.TripModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -56,6 +57,20 @@ class TripViewModel constructor(
             context.contentResolver.openOutputStream(uri)?.let {
                 useCase.execute(it)
             }
+        }
+    }
+
+    fun updateTrip(tripModel: TripModel) {
+        viewModelScope.launch {
+            val useCase = tripUseCaseFactory.createUpdateUseCase()
+            useCase.execute(tripModel.toTrip())
+        }
+    }
+
+    fun deleteTrip(tripModel: TripModel) {
+        viewModelScope.launch {
+            val useCase = tripUseCaseFactory.createDeleteUseCase()
+            useCase.execute(tripModel.toTrip())
         }
     }
 


### PR DESCRIPTION
This commit introduces the functionality to update and delete trips.

The following changes have been made:
- Added `updateTrip` and `deleteTrip` methods to `TripRepository`.
- Created `UpdateTripUseCase` and `DeleteTripUseCase` to handle the business logic for updating and deleting trips.
- Updated `TripUseCaseFactory` to create instances of the new use cases.
- Added `updateTrip` and `deleteTrip` methods to `TripViewModel` to expose the new functionality to the UI layer.