### PR TITLE
Refactor import/export buttons to an action bar menu

### DIFF
--- a/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripScreen.kt
@@ -2,33 +2,45 @@ package com.kerberos.trackingSdk.ui.trip
 
 import android.app.Activity
 import android.content.Intent
-import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.kerberos.trackingSdk.viewModels.TripViewModel
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TripScreen(viewModel: TripViewModel = koinViewModel()) {
     val lazyTripItems = viewModel.tripList.collectAsLazyPagingItems()
+    var showMenu by remember { mutableStateOf(false) }
 
     val importCsvLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -70,61 +82,72 @@ fun TripScreen(viewModel: TripViewModel = koinViewModel()) {
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            Button(onClick = {
-                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "text/csv"
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Trips") },
+                actions = {
+                    IconButton(onClick = { showMenu = !showMenu }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "More")
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Import CSV") },
+                            onClick = {
+                                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "text/csv"
+                                }
+                                importCsvLauncher.launch(intent)
+                                showMenu = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Export CSV") },
+                            onClick = {
+                                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "text/csv"
+                                    putExtra(Intent.EXTRA_TITLE, "trips.csv")
+                                }
+                                exportCsvLauncher.launch(intent)
+                                showMenu = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Import JSON") },
+                            onClick = {
+                                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "application/json"
+                                }
+                                importJsonLauncher.launch(intent)
+                                showMenu = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Export JSON") },
+                            onClick = {
+                                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "application/json"
+                                    putExtra(Intent.EXTRA_TITLE, "trips.json")
+                                }
+                                exportJsonLauncher.launch(intent)
+                                showMenu = false
+                            }
+                        )
+                    }
                 }
-                importCsvLauncher.launch(intent)
-            }) {
-                Text(text = "Import CSV")
-            }
-            Button(onClick = {
-                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "text/csv"
-                    putExtra(Intent.EXTRA_TITLE, "trips.csv")
-                }
-                exportCsvLauncher.launch(intent)
-            }) {
-                Text(text = "Export CSV")
-            }
+            )
         }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            Button(onClick = {
-                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "application/json"
-                }
-                importJsonLauncher.launch(intent)
-            }) {
-                Text(text = "Import JSON")
-            }
-            Button(onClick = {
-                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "application/json"
-                    putExtra(Intent.EXTRA_TITLE, "trips.json")
-                }
-                exportJsonLauncher.launch(intent)
-            }) {
-                Text(text = "Export JSON")
-            }
-        }
-
-        Box(modifier = Modifier.weight(1f)) {
+    ) { paddingValues ->
+        Box(modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -136,11 +159,9 @@ fun TripScreen(viewModel: TripViewModel = koinViewModel()) {
                 }
             }
 
-            // Handle load states: initial loading, error, empty
             val refreshState = lazyTripItems.loadState.refresh
             val appendState = lazyTripItems.loadState.append
             if (refreshState is LoadState.Loading && lazyTripItems.itemCount == 0) {
-                // initial loading
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             } else if (refreshState is LoadState.Error && lazyTripItems.itemCount == 0) {
                 val error = (refreshState as LoadState.Error).error
@@ -155,7 +176,6 @@ fun TripScreen(viewModel: TripViewModel = koinViewModel()) {
                     }
                 }
             } else if (appendState is LoadState.Error) {
-                // show small retry when appending pages fail
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -178,33 +198,3 @@ fun TripScreen(viewModel: TripViewModel = koinViewModel()) {
         }
     }
 }
-
-//            lazyTripItems.loadState.let { loadState ->
-//                if (loadState.refresh is LoadState.Loading) {
-//                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-//                }
-//                if (loadState.refresh is LoadState.Error) {
-//                    val error = (loadState.refresh as LoadState.Error).error
-//                    Column(
-//                        modifier = Modifier.fillMaxSize(),
-//                        verticalArrangement = Arrangement.Center,
-//                        horizontalAlignment = Alignment.CenterHorizontally
-//                    ) {
-//                        Text(text = "Error: ${error.message}")
-//                        Button(onClick = { lazyTripItems.retry() }) {
-//                            Text(text = "Retry")
-//                        }
-//                    }
-//                }
-//                if (loadState.append.endOfPaginationReached && lazyTripItems.itemCount == 0) {
-//                    Box(
-//                        modifier = Modifier.fillMaxSize(),
-//                        contentAlignment = Alignment.Center
-//                    ) {
-//                        Text(text = "No trips found.")
-//                    }
-//                }
-//            }
-//        }
-//    }
-//}


### PR DESCRIPTION
- Replaced the import/export buttons on the TripScreen with a TopAppBar and an overflow menu.
- The menu now contains the options to import and export trips as CSV or JSON.
- This change improves the UI by decluttering the screen and grouping related actions together.