### PR TITLE
feat: Add LiveTrackingViewModel to manage the liveTrackingSdk

### DIFF
--- a/app/src/main/java/com/kerberos/trackingSdk/MainActivity.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/MainActivity.kt
@@ -12,76 +12,23 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.kerberos.livetrackingsdk.LiveTrackingManager
-import com.kerberos.livetrackingsdk.enums.LiveTrackingMode
-import com.kerberos.livetrackingsdk.enums.TrackingState
-import com.kerberos.livetrackingsdk.interfaces.ITrackingLocationListener
-import com.kerberos.livetrackingsdk.interfaces.ITrackingStatusListener
-import com.kerberos.trackingSdk.viewModels.TripStatus
 import com.kerberos.trackingSdk.ui.BottomNavigationBar
+import com.kerberos.trackingSdk.ui.LiveTrackingScreen
 import com.kerberos.trackingSdk.ui.theme.ui.theme.MyApplicationTheme
 import com.kerberos.trackingSdk.ui.trip.TripMapScreen
 import com.kerberos.trackingSdk.ui.trip.TripScreen
 import com.kerberos.trackingSdk.ui.settings.SettingsScreen
-import com.kerberos.trackingSdk.ui.trip.TripControls
-import kotlinx.coroutines.DelicateCoroutinesApi
-import timber.log.Timber
 
-@OptIn(DelicateCoroutinesApi::class)
 class MainActivity : ComponentActivity() {
-
-    private val liveTrackingManager: LiveTrackingManager by lazy {
-        LiveTrackingManager.Builder(this)
-            .setLocationUpdateInterval(1000L)
-            .setMinDistanceMeters(5f)
-            .setBackgroundService(TripBackgroundService::class.java)
-            .setLiveTrackingMode(LiveTrackingMode.BACKGROUND_SERVICE)
-            .build()
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             MyApplicationTheme {
-                TripControls(
-                    tripStatus = TripStatus.RUNNING,
-                    onStart = {
-                        liveTrackingManager.onStartTracking()
-                    },
-                    onPause = {
-                        liveTrackingManager.onPauseTracking()
-                    },
-                    onResume = {
-                        liveTrackingManager.onResumeTracking()
-                    },
-                    onStop = {
-                        liveTrackingManager.onStopTracking()
-                    }
-                )
                 MainScreen()
             }
         }
-        liveTrackingManager.currentTrackingManager.initializeTrackingManager()
-        liveTrackingManager.onStartTracking()
-
-        liveTrackingManager.addTrackingLocationListener(listener = object :
-            ITrackingLocationListener {
-            override fun onLocationUpdated(currentLocation: Location?) {
-                Timber.d("onLocationUpdated")
-            }
-
-            override fun onLocationUpdateFailed(exception: Exception) {
-                Timber.d("onLocationUpdateFailed")
-            }
-        })
-
-        liveTrackingManager.addTrackingStatusListener(listener = object :
-            ITrackingStatusListener {
-            override fun onTrackingStateChanged(trackingState: TrackingState) {
-                Timber.d("onTrackingStateChanged")
-            }
-        })
     }
 
 }
@@ -100,6 +47,7 @@ fun MainScreen() {
             composable("Map") { TripMapScreen() }
             composable("List") { TripScreen() }
             composable("Settings") { SettingsScreen() }
+            composable("Live") { LiveTrackingScreen() }
         }
     }
 }

--- a/app/src/main/java/com/kerberos/trackingSdk/di/KoinStarter.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/di/KoinStarter.kt
@@ -8,6 +8,7 @@ import com.kerberos.trackingSdk.orm.LiveTrackingDatabase
 import com.kerberos.trackingSdk.repositories.repositories.TripPagingRepositoryImpl
 import com.kerberos.trackingSdk.repositories.repositories.TripRepository
 import com.kerberos.trackingSdk.repositories.repositories.TripTrackRepository
+import com.kerberos.trackingSdk.viewModels.LiveTrackingViewModel
 import com.kerberos.trackingSdk.viewModels.SettingsViewModel
 import com.kerberos.trackingSdk.viewModels.TripTrackViewModel
 import com.kerberos.trackingSdk.viewModels.TripViewModel
@@ -40,6 +41,7 @@ object KoinStarter {
         viewModel { TripTrackViewModel(get()) }
         viewModel { TripViewModel(get(), get(), get()) }
         viewModel { SettingsViewModel(get()) }
+        viewModel { LiveTrackingViewModel(get()) }
     }
 
     private val repositoryModule = module {

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/BottomNavigationBar.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/BottomNavigationBar.kt
@@ -2,6 +2,7 @@ package com.kerberos.trackingSdk.ui
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
@@ -18,8 +19,8 @@ import androidx.navigation.NavController
 @Composable
 fun BottomNavigationBar(navController: NavController) {
     var selectedItem by remember { mutableStateOf(0) }
-    val items = listOf("Map", "List", "Settings")
-    val icons = listOf(Icons.Filled.Place, Icons.AutoMirrored.Filled.List, Icons.Filled.Settings)
+    val items = listOf("Map", "List", "Settings", "Live")
+    val icons = listOf(Icons.Filled.Place, Icons.AutoMirrored.Filled.List, Icons.Filled.Settings, Icons.Filled.LocationOn)
 
     NavigationBar {
         items.forEachIndexed { index, item ->

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/LiveTrackingScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/LiveTrackingScreen.kt
@@ -1,0 +1,70 @@
+package com.kerberos.trackingSdk.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.kerberos.livetrackingsdk.enums.TrackingState
+import com.kerberos.trackingSdk.viewModels.LiveTrackingViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun LiveTrackingScreen(
+    viewModel: LiveTrackingViewModel = koinViewModel(),
+) {
+    val trackingState by viewModel.trackingState.collectAsState()
+    val locationState by viewModel.locationState.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = "Tracking State: ${trackingState.name}")
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(text = "Location: ${locationState?.latitude}, ${locationState?.longitude}")
+        Spacer(modifier = Modifier.height(32.dp))
+        Row {
+            Button(
+                onClick = { viewModel.startTracking() },
+                enabled = trackingState == TrackingState.STOPPED
+            ) {
+                Text("Start")
+            }
+            Button(
+                onClick = { viewModel.stopTracking() },
+                enabled = trackingState != TrackingState.STOPPED
+            ) {
+                Text("Stop")
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row {
+            Button(
+                onClick = { viewModel.pauseTracking() },
+                enabled = trackingState == TrackingState.TRACKING
+            ) {
+                Text("Pause")
+            }
+            Button(
+                onClick = { viewModel.resumeTracking() },
+                enabled = trackingState == TrackingState.PAUSED
+            ) {
+                Text("Resume")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kerberos/trackingSdk/viewModels/LiveTrackingViewModel.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/viewModels/LiveTrackingViewModel.kt
@@ -1,0 +1,70 @@
+package com.kerberos.trackingSdk.viewModels
+
+import android.app.Application
+import android.location.Location
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.kerberos.livetrackingsdk.LiveTrackingManager
+import com.kerberos.livetrackingsdk.enums.TrackingState
+import com.kerberos.livetrackingsdk.interfaces.ITrackingLocationListener
+import com.kerberos.livetrackingsdk.interfaces.ITrackingStatusListener
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class LiveTrackingViewModel(application: Application) : AndroidViewModel(application),
+    ITrackingStatusListener, ITrackingLocationListener {
+
+    private val _trackingState = MutableStateFlow<TrackingState>(TrackingState.STOPPED)
+    val trackingState: StateFlow<TrackingState> = _trackingState
+
+    private val _locationState = MutableStateFlow<Location?>(null)
+    val locationState: StateFlow<Location?> = _locationState
+
+    private val liveTrackingManager: LiveTrackingManager = LiveTrackingManager.Builder(application)
+        .build()
+
+    init {
+        liveTrackingManager.addTrackingStatusListener(this)
+        liveTrackingManager.addTrackingLocationListener(this)
+        liveTrackingManager.currentTrackingManager.initializeTrackingManager()
+    }
+
+    fun startTracking() {
+        liveTrackingManager.onStartTracking()
+    }
+
+    fun stopTracking() {
+        liveTrackingManager.onStopTracking()
+    }
+
+    fun pauseTracking() {
+        liveTrackingManager.onPauseTracking()
+    }
+
+    fun resumeTracking() {
+        liveTrackingManager.onResumeTracking()
+    }
+
+    override fun onTrackingStateChanged(state: TrackingState) {
+        viewModelScope.launch {
+            _trackingState.value = state
+        }
+    }
+
+    override fun onLocationUpdated(currentLocation: Location?) {
+        viewModelScope.launch {
+            _locationState.value = currentLocation
+        }
+    }
+
+    override fun onLocationUpdateFailed(exception: Exception) {
+        // Handle the error, e.g., log it or show a message to the user
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        liveTrackingManager.removeTrackingStatusListener(this)
+        liveTrackingManager.removeTrackingLocationListener(this)
+    }
+}


### PR DESCRIPTION
This commit introduces a new `LiveTrackingViewModel` that encapsulates the logic for interacting with the `liveTrackingSdk`.

Key changes:
- Created `LiveTrackingViewModel` to manage the `LiveTrackingManager`.
- The ViewModel exposes tracking state and location updates as `StateFlows`.
- Created a new `LiveTrackingScreen` to display the live tracking data and provide user controls.
- Updated the navigation to include the new screen.
- Registered the new ViewModel with Koin for dependency injection.
- Removed the live tracking logic from `MainActivity`.