### PR TITLE
Feat: Detect current location on map open

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.accompanist.permissions)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)

--- a/app/src/main/java/com/kerberos/trackingSdk/di/KoinStarter.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/di/KoinStarter.kt
@@ -11,6 +11,7 @@ import com.kerberos.trackingSdk.repositories.repositories.TripTrackRepository
 import com.kerberos.trackingSdk.viewModels.SettingsViewModel
 import com.kerberos.trackingSdk.viewModels.TripTrackViewModel
 import com.kerberos.trackingSdk.viewModels.TripViewModel
+import com.kerberos.livetrackingsdk.managers.LocationTrackingManager
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -30,14 +31,19 @@ object KoinStarter {
                     viewModelModule,
                     factoryModule,
                     serializationModule,
-                    storageModule
+                    storageModule,
+                    managerModule
                 )
             )
         }
     }
 
+    private val managerModule = module {
+        single { LocationTrackingManager(get()) }
+    }
+
     private val viewModelModule = module {
-        viewModel { TripTrackViewModel(get()) }
+        viewModel { TripTrackViewModel(get(), get()) }
         viewModel { TripViewModel(get(), get(), get()) }
         viewModel { SettingsViewModel(get()) }
     }

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripMapScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/trip/TripMapScreen.kt
@@ -1,15 +1,22 @@
 package com.kerberos.trackingSdk.ui.trip
 
+import android.Manifest
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberPermissionState
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -18,27 +25,46 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import com.kerberos.trackingSdk.viewModels.TripTrackViewModel
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun TripMapScreen(viewModel: TripTrackViewModel = koinViewModel()) {
     val tripTracks by viewModel.tripTracks.collectAsState()
     val tripStatus by viewModel.tripStatus.collectAsState()
+    val currentLocation by viewModel.currentLocation.collectAsState()
+    var cameraInitialized by remember { mutableStateOf(false) }
+
 
     val cameraPositionState = rememberCameraPositionState {
         position = CameraPosition.fromLatLngZoom(LatLng(0.0, 0.0), 10f)
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.getTripTracks(1) // todo: pass trip id
+    val locationPermissionState = rememberPermissionState(
+        Manifest.permission.ACCESS_FINE_LOCATION
+    )
+
+    LaunchedEffect(locationPermissionState.hasPermission) {
+        if (locationPermissionState.hasPermission) {
+            viewModel.startLocationUpdates()
+        } else {
+            locationPermissionState.launchPermissionRequest()
+        }
     }
 
-    LaunchedEffect(tripTracks) {
-        if (tripTracks.isNotEmpty()) {
-            val firstTrack = tripTracks.first()
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.stopLocationUpdates()
+        }
+    }
+
+    LaunchedEffect(currentLocation) {
+        if (currentLocation != null && !cameraInitialized) {
             cameraPositionState.position =
                 CameraPosition.fromLatLngZoom(
-                    LatLng(firstTrack.latitude, firstTrack.longitude),
+                    currentLocation!!,
                     15f
                 )
+            cameraInitialized = true
+            viewModel.stopLocationUpdates()
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,8 +29,10 @@ navigationRuntimeAndroid = "2.9.3"
 playServicesMapsVersion = "18.2.0"
 roomRuntime = "2.7.2"
 timber = "5.0.1"
+accompanist-permissions = "0.34.0"
 
 [libraries]
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist-permissions" }
 androidx-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "adaptiveNavigation" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }


### PR DESCRIPTION
This commit implements the feature to detect the user's current location and center the map on it when the map screen is opened.

Changes include:
- Added `accompanist-permissions` library to handle runtime location permissions.
- Updated Koin dependency injection to provide `LocationTrackingManager`.
- Updated `TripTrackViewModel` to handle location updates from `LocationTrackingManager`.
- Updated `TripMapScreen` to request location permissions and display the current location on the map.