### PR TITLE
feat: Add distance setting to the settings page

### DIFF
--- a/app/src/main/java/com/kerberos/trackingSdk/di/KoinStarter.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/di/KoinStarter.kt
@@ -47,7 +47,7 @@ object KoinStarter {
         viewModel { TripTrackViewModel(get(), get()) }
         viewModel { TripViewModel(get(), get(), get()) }
         viewModel { SettingsViewModel(get()) }
-        viewModel { LiveTrackingViewModel(get()) }
+        viewModel { LiveTrackingViewModel(get(), get()) }
     }
 
     private val repositoryModule = module {

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/settings/SettingsScreen.kt
@@ -41,6 +41,14 @@ fun SettingsScreen(viewModel: SettingsViewModel = koinViewModel()) {
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(16.dp))
+        TextField(
+            value = uiState.minDistance,
+            onValueChange = viewModel::onMinDistanceChanged,
+            label = { Text("Minimum Distance (meters)") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/kerberos/trackingSdk/viewModels/LiveTrackingViewModel.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/viewModels/LiveTrackingViewModel.kt
@@ -12,7 +12,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class LiveTrackingViewModel(application: Application) : AndroidViewModel(application),
+class LiveTrackingViewModel(
+    application: Application,
+    private val appPrefsStorage: com.kerberos.trackingSdk.dataStore.AppPrefsStorage
+) : AndroidViewModel(application),
     ITrackingStatusListener, ITrackingLocationListener {
 
     private val _trackingState = MutableStateFlow<TrackingState>(TrackingState.STOPPED)
@@ -28,6 +31,14 @@ class LiveTrackingViewModel(application: Application) : AndroidViewModel(applica
         liveTrackingManager.addTrackingStatusListener(this)
         liveTrackingManager.addTrackingLocationListener(this)
         liveTrackingManager.currentTrackingManager.initializeTrackingManager()
+
+        viewModelScope.launch {
+            appPrefsStorage.trackSDKConfiguration.collect { settings ->
+                settings?.let {
+                    liveTrackingManager.changeSdkSettings(it)
+                }
+            }
+        }
     }
 
     fun startTracking() {

--- a/app/src/main/java/com/kerberos/trackingSdk/viewModels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/viewModels/SettingsViewModel.kt
@@ -25,7 +25,8 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
             val config = appPrefsStorage.trackSDKConfiguration.first()
             _uiState.value = SettingsUiState(
                 locationUpdateInterval = config?.locationUpdateInterval?.toString() ?: "10000",
-                backgroundTrackingEnabled = config?.backgroundTrackingToggle ?: false
+                backgroundTrackingEnabled = config?.backgroundTrackingToggle ?: false,
+                minDistance = config?.minDistanceMeters?.toString() ?: "25"
             )
         }
     }
@@ -38,13 +39,17 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
         _uiState.value = _uiState.value.copy(backgroundTrackingEnabled = enabled)
     }
 
+    fun onMinDistanceChanged(distance: String) {
+        _uiState.value = _uiState.value.copy(minDistance = distance)
+    }
+
     fun saveSettings() {
         viewModelScope.launch {
             val currentConfig = SdkSettings(
                 locationUpdateInterval = _uiState.value.locationUpdateInterval.toLongOrNull()
                     ?: 10000L,
                 backgroundTrackingToggle = _uiState.value.backgroundTrackingEnabled,
-                minDistanceMeters = 25f
+                minDistanceMeters = _uiState.value.minDistance.toFloatOrNull() ?: 25f
             )
             appPrefsStorage.setTrackSDKConfiguration(currentConfig)
         }
@@ -53,5 +58,6 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
 
 data class SettingsUiState(
     val locationUpdateInterval: String = "10000",
-    val backgroundTrackingEnabled: Boolean = false
+    val backgroundTrackingEnabled: Boolean = false,
+    val minDistance: String = "25"
 )

--- a/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/dataStore/SdkPreferencesManager.kt
+++ b/liveTrackingSdk/src/main/java/com/kerberos/livetrackingsdk/dataStore/SdkPreferencesManager.kt
@@ -76,6 +76,7 @@ class SdkPreferencesManager(context: Context) {
     fun updateAllSettings(newSettings: SdkSettings) {
         sharedPreferences.edit {
             putLong(PreferencesKeys.LOCATION_UPDATE_INTERVAL, newSettings.locationUpdateInterval)
+            putFloat(PreferencesKeys.LOCATION_UPDATE_DISTANCE, newSettings.minDistanceMeters)
             putBoolean(
                 PreferencesKeys.BACKGROUND_TRACKING_TOGGLE,
                 newSettings.backgroundTrackingToggle


### PR DESCRIPTION
This change introduces a new setting for minimum distance on the settings page.

The new setting is persisted using `AppPrefsStorage` and is used to configure the `LiveTrackingManager` in the `liveTrackingSdk`.

The implementation follows the MVVM pattern, with the `SettingsViewModel` managing the UI state and the `LiveTrackingViewModel` observing the settings and reconfiguring the `LiveTrackingManager` accordingly.