### PR TITLE
Feat: Add language and theme settings

### DIFF
--- a/app/src/main/java/com/kerberos/trackingSdk/BaseActivity.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/BaseActivity.kt
@@ -1,0 +1,29 @@
+package com.kerberos.trackingSdk
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatActivity
+import com.kerberos.trackingSdk.dataStore.AppPrefsStorage
+import kotlinx.coroutines.runBlocking
+import java.util.Locale
+
+abstract class BaseActivity : AppCompatActivity() {
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(updateBaseContextLocale(newBase))
+    }
+
+    private fun updateBaseContextLocale(context: Context): Context {
+        val language = runBlocking { AppPrefsStorage(context).getLanguage() }
+        val locale = if (language == "Spanish") {
+            Locale("es")
+        } else {
+            Locale.ENGLISH
+        }
+        Locale.setDefault(locale)
+
+        val config = Configuration(context.resources.configuration)
+        config.setLocale(locale)
+        return context.createConfigurationContext(config)
+    }
+}

--- a/app/src/main/java/com/kerberos/trackingSdk/MainActivity.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/MainActivity.kt
@@ -1,36 +1,55 @@
 package com.kerberos.trackingSdk
 
-import android.location.Location
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.kerberos.trackingSdk.dataStore.AppPrefsStorage
 import com.kerberos.trackingSdk.ui.BottomNavigationBar
 import com.kerberos.trackingSdk.ui.LiveTrackingScreen
+import com.kerberos.trackingSdk.ui.settings.SettingsScreen
 import com.kerberos.trackingSdk.ui.theme.ui.theme.MyApplicationTheme
 import com.kerberos.trackingSdk.ui.trip.TripMapScreen
 import com.kerberos.trackingSdk.ui.trip.TripScreen
-import com.kerberos.trackingSdk.ui.settings.SettingsScreen
+import kotlinx.coroutines.flow.map
+import org.koin.android.ext.android.inject
 
-class MainActivity : ComponentActivity() {
+class MainActivity : BaseActivity() {
+
+    private val appPrefsStorage: AppPrefsStorage by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
+
+            val theme by appPrefsStorage.getThemeFlow().collectAsState(initial = "Light")
+
+            LaunchedEffect(theme) {
+                val mode = when (theme) {
+                    "Dark" -> AppCompatDelegate.MODE_NIGHT_YES
+                    "Light" -> AppCompatDelegate.MODE_NIGHT_NO
+                    else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                }
+                AppCompatDelegate.setDefaultNightMode(mode)
+            }
+
+
             MyApplicationTheme {
                 MainScreen()
             }
         }
     }
-
 }
 
 @Composable

--- a/app/src/main/java/com/kerberos/trackingSdk/dataStore/AppPrefsStorage.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/dataStore/AppPrefsStorage.kt
@@ -32,6 +32,26 @@ class AppPrefsStorage(var context: Context) : PreferenceStorage {
             Gson().toJson(loggedUser)
         )
     }
+
+    override suspend fun getLanguage(): String? {
+        return context.dataStore.getValue(PreferencesKeys.LANGUAGE, "English")
+    }
+
+    override suspend fun saveLanguage(language: String) {
+        context.dataStore.setValue(PreferencesKeys.LANGUAGE, language)
+    }
+
+    override suspend fun getTheme(): String? {
+        return context.dataStore.getValue(PreferencesKeys.THEME, "Light")
+    }
+
+    override fun getThemeFlow(): Flow<String?> {
+        return context.dataStore.getValueAsFlow(PreferencesKeys.THEME, "Light")
+    }
+
+    override suspend fun saveTheme(theme: String) {
+        context.dataStore.setValue(PreferencesKeys.THEME, theme)
+    }
     //endregion
 
     /***
@@ -83,4 +103,11 @@ class AppPrefsStorage(var context: Context) : PreferenceStorage {
         }
     }
 
+    private suspend fun <T> DataStore<Preferences>.getValue(
+        key: Preferences.Key<T>,
+        defaultValue: T
+    ): T {
+        val preferences = this.data.first()
+        return preferences[key] ?: defaultValue
+    }
 }

--- a/app/src/main/java/com/kerberos/trackingSdk/dataStore/PreferenceStorage.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/dataStore/PreferenceStorage.kt
@@ -8,6 +8,13 @@ interface PreferenceStorage {
     val trackSDKConfiguration: Flow<SdkSettings?>
     suspend fun setTrackSDKConfiguration(configuration: SdkSettings)
 
+    suspend fun getLanguage(): String?
+    suspend fun saveLanguage(language: String)
+
+    suspend fun getTheme(): String?
+    fun getThemeFlow(): Flow<String?>
+    suspend fun saveTheme(theme: String)
+
     /***
      * clears all the stored data
      */

--- a/app/src/main/java/com/kerberos/trackingSdk/dataStore/PreferencesKeys.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/dataStore/PreferencesKeys.kt
@@ -4,4 +4,6 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 
 object PreferencesKeys {
     val TRACK_SDK_CONFIGURATION = stringPreferencesKey("TrackSDKConfiguration")
+    val LANGUAGE = stringPreferencesKey("Language")
+    val THEME = stringPreferencesKey("Theme")
 }

--- a/app/src/main/java/com/kerberos/trackingSdk/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/ui/settings/SettingsScreen.kt
@@ -10,12 +10,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
@@ -23,9 +30,15 @@ import androidx.compose.ui.unit.dp
 import com.kerberos.trackingSdk.viewModels.SettingsViewModel
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(viewModel: SettingsViewModel = koinViewModel()) {
     val uiState by viewModel.uiState.collectAsState()
+    var languageExpanded by remember { mutableStateOf(false) }
+    var themeExpanded by remember { mutableStateOf(false) }
+
+    val languages = listOf("English", "Spanish")
+    val themes = listOf("Light", "Dark")
 
     Column(
         modifier = Modifier
@@ -59,6 +72,70 @@ fun SettingsScreen(viewModel: SettingsViewModel = koinViewModel()) {
                 checked = uiState.backgroundTrackingEnabled,
                 onCheckedChange = viewModel::onBackgroundTrackingChanged
             )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        ExposedDropdownMenuBox(
+            expanded = languageExpanded,
+            onExpandedChange = { languageExpanded = !languageExpanded }
+        ) {
+            TextField(
+                value = uiState.language,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Language") },
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = languageExpanded)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+            )
+            ExposedDropdownMenu(
+                expanded = languageExpanded,
+                onDismissRequest = { languageExpanded = false }
+            ) {
+                languages.forEach { language ->
+                    DropdownMenuItem(
+                        text = { Text(language) },
+                        onClick = {
+                            viewModel.onLanguageChanged(language)
+                            languageExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        ExposedDropdownMenuBox(
+            expanded = themeExpanded,
+            onExpandedChange = { themeExpanded = !themeExpanded }
+        ) {
+            TextField(
+                value = uiState.theme,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Theme") },
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = themeExpanded)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+            )
+            ExposedDropdownMenu(
+                expanded = themeExpanded,
+                onDismissRequest = { themeExpanded = false }
+            ) {
+                themes.forEach { theme ->
+                    DropdownMenuItem(
+                        text = { Text(theme) },
+                        onClick = {
+                            viewModel.onThemeChanged(theme)
+                            themeExpanded = false
+                        }
+                    )
+                }
+            }
         }
         Spacer(modifier = Modifier.height(32.dp))
         Button(onClick = viewModel::saveSettings) {

--- a/app/src/main/java/com/kerberos/trackingSdk/viewModels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kerberos/trackingSdk/viewModels/SettingsViewModel.kt
@@ -26,7 +26,9 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
             _uiState.value = SettingsUiState(
                 locationUpdateInterval = config?.locationUpdateInterval?.toString() ?: "10000",
                 backgroundTrackingEnabled = config?.backgroundTrackingToggle ?: false,
-                minDistance = config?.minDistanceMeters?.toString() ?: "25"
+                minDistance = config?.minDistanceMeters?.toString() ?: "25",
+                language = appPrefsStorage.getLanguage() ?: "English",
+                theme = appPrefsStorage.getTheme() ?: "Light"
             )
         }
     }
@@ -43,6 +45,14 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
         _uiState.value = _uiState.value.copy(minDistance = distance)
     }
 
+    fun onLanguageChanged(language: String) {
+        _uiState.value = _uiState.value.copy(language = language)
+    }
+
+    fun onThemeChanged(theme: String) {
+        _uiState.value = _uiState.value.copy(theme = theme)
+    }
+
     fun saveSettings() {
         viewModelScope.launch {
             val currentConfig = SdkSettings(
@@ -52,6 +62,8 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
                 minDistanceMeters = _uiState.value.minDistance.toFloatOrNull() ?: 25f
             )
             appPrefsStorage.setTrackSDKConfiguration(currentConfig)
+            appPrefsStorage.saveLanguage(_uiState.value.language)
+            appPrefsStorage.saveTheme(_uiState.value.theme)
         }
     }
 }
@@ -59,5 +71,7 @@ class SettingsViewModel(private val appPrefsStorage: AppPrefsStorage) :
 data class SettingsUiState(
     val locationUpdateInterval: String = "10000",
     val backgroundTrackingEnabled: Boolean = false,
-    val minDistance: String = "25"
+    val minDistance: String = "25",
+    val language: String = "English",
+    val theme: String = "Light"
 )

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,4 +6,11 @@
     <string name="Retry">Reintentar</string>
     <string name="youAreNotAuthorized">No estás autorizado</string>
     <string name="internalServerError">Error interno del servidor</string>
+
+    <string name="setting_language">Idioma</string>
+    <string name="setting_theme">Tema</string>
+    <string name="setting_language_english">Inglés</string>
+    <string name="setting_language_spanish">Español</string>
+    <string name="setting_theme_light">Claro</string>
+    <string name="setting_theme_dark">Oscuro</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,11 @@
     <string name="Retry">Retry</string>
     <string name="youAreNotAuthorized">You are not authorized</string>
     <string name="internalServerError">Internal server error</string>
+
+    <string name="setting_language">Language</string>
+    <string name="setting_theme">Theme</string>
+    <string name="setting_language_english">English</string>
+    <string name="setting_language_spanish">Spanish</string>
+    <string name="setting_theme_light">Light</string>
+    <string name="setting_theme_dark">Dark</string>
 </resources>


### PR DESCRIPTION
This commit introduces language and theme selection options in the settings screen.

- Adds dropdowns in the UI for language (English/Spanish) and theme (Light/Dark).
- Persists the selected settings using DataStore.
- Implements a BaseActivity to apply the selected language across the app.
- Dynamically updates the app's theme based on the selected preference.